### PR TITLE
Fix for duplicate values using setState with initially selected items

### DIFF
--- a/flutter_multi_select/lib/src/containers/multi_select_container.dart
+++ b/flutter_multi_select/lib/src/containers/multi_select_container.dart
@@ -119,7 +119,7 @@ class _SimpleMultiSelectContainerState<T>
 
   @override
   void didUpdateWidget(MultiSelectContainer<T> oldWidget) {
-    _addInitiallySelectedItemsToSelectedList();
+    _setPerpetualSelectedItemsCount();
     if (widget.controller != null) {
       widget.controller!.deselectAll = oldWidget.controller!.deselectAll;
       widget.controller!.getSelectedItems =
@@ -129,12 +129,19 @@ class _SimpleMultiSelectContainerState<T>
     super.didUpdateWidget(oldWidget);
   }
 
-  //add initially selected items and find perpetual selected items count
+  // add initially selected items and find perpetual selected items count
   void _addInitiallySelectedItemsToSelectedList() {
     final initiallySelected = _items
         .where((item) => item.selected || item.perpetualSelected)
         .toList();
     _selectedItems.addAll(initiallySelected);
+    _perpetualSelectedItemsCount =
+        _items.where((item) => item.perpetualSelected).length;
+    setState(() {});
+  }
+
+  // find perpetual selected items count
+  void _setPerpetualSelectedItemsCount() {
     _perpetualSelectedItemsCount =
         _items.where((item) => item.perpetualSelected).length;
     setState(() {});


### PR DESCRIPTION
Fix for duplicate values appearing for each call to setState when initializing MultiSelectContainer with pre-selected items.  For example when initializing `MultiSelectContainer` like this:

```dart
MultiSelectContainer(
  controller: _controller,
  items: _myItems.map((item) => MultiSelectCard(value: item, label: item.name, selected: _mySelectedItems.any((s) => s.id == item.id))).toList(),
),
```
In the above example I am setting some of the initial `_myItems` to `selected: true` based on their existence in `_mySelectedItems`.

The reason the selected values were being duplicated is because `didUpdateWidget` would call `_addInitiallySelectedItemsToSelectedList` which would blindly add those items to `_selectedItems`.  This is OK in `initState` because it is only called once when the widget is created.  But it is a problem in `didUpdateWidget` because it is called whenever the widget is updated, thus adding the same items to `_selectedItems` again and again.