### PR TITLE
(feat) Add Screen Reader Support to MultiSelectContainer

### DIFF
--- a/flutter_multi_select/lib/src/containers/multi_select_container.dart
+++ b/flutter_multi_select/lib/src/containers/multi_select_container.dart
@@ -376,8 +376,10 @@ class _SimpleMultiSelectContainerState<T>
                     style: getTextStyle(item.textStyles, widget.textStyles,
                         isSelected, item.enabled, context),
                     child: item.child ??
-                        Text(
-                          item.label!,
+                        Semantics(
+                          toggled: isSelected,
+                          enabled: item.enabled,
+                          child: Text(item.label!,)
                         ),
                   ),
                   _suffix == null


### PR DESCRIPTION
Previously, the iOS screen reader would just say the text on the multi select item, but not say if it was toggleable and also not say the current state.  This change allows the screen reader to say all of that information.  I only added screen reader support to the default Text widget and not to the custom child widget functionality because for the custom widget a user can include their own screen reader support if desired.